### PR TITLE
scalablyTyped-converterのバージョン指定方法を変更（元の方法はscala-stewardが検知してくれなかったので）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
         path: |
           ~/.cache/scalablytyped/
           ~/.ivy2/local/org.scalablytyped/
-        key: ${{ runner.os }}-scalablytyped-v0-${{ hashFiles('project/project/ScalablyTyped.scala') }}-${{ hashFiles('project/Dependencies.scala') }}
+        key: ${{ runner.os }}-scalablytyped-v0-${{ hashFiles('project/scalablyTyped.sbt') }}-${{ hashFiles('project/Dependencies.scala') }}
         # restore-keys には必ずScalablyTyped.scalaのhashをつける。 ScalablyTypedのバージョンが変わったら必ずキャッシュを新規に作りたい（そうしないと古いバージョンのキャッシュが残り続ける
         restore-keys: |
-          ${{ runner.os }}-scalablytyped-v0-${{ hashFiles('project/project/ScalablyTyped.scala') }}-
+          ${{ runner.os }}-scalablytyped-v0-${{ hashFiles('project/scalablyTyped.sbt') }}-
     - name: Build and Test
       run: ./sbt-batch reformatCheck test

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,6 +7,5 @@ addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.10.1")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.2.0")
 addSbtPlugin("ch.epfl.scala"      % "sbt-scalajs-bundler"      % "0.21.0")
 
-addSbtPlugin("org.scalablytyped.converter" % "sbt-converter" % ScalablyTyped.version)
-addSbtPlugin("com.typesafe.sbt"            % "sbt-ghpages"   % "0.6.3")
-addSbtPlugin("com.typesafe.sbt"            % "sbt-site"      % "1.4.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.3")
+addSbtPlugin("com.typesafe.sbt" % "sbt-site"    % "1.4.1")

--- a/project/project/ScalablyTyped.scala
+++ b/project/project/ScalablyTyped.scala
@@ -1,5 +1,0 @@
-object ScalablyTyped {
-  // このファイルをgithub actionsのcacheで監視することで、バージョンごと保存するキャッシュを分離する
-  // こうしておかないとScalablyTypedのキャッシュが無限に大きくなる
-  val version = "1.0.0-beta37"
-}

--- a/project/scalablyTyped.sbt
+++ b/project/scalablyTyped.sbt
@@ -1,0 +1,3 @@
+// このファイルをgithub actionsのcacheで監視することで、バージョンごと保存するキャッシュを分離する
+// こうしておかないとScalablyTypedのキャッシュが無限に大きくなる
+addSbtPlugin("org.scalablytyped.converter" % "sbt-converter" % "1.0.0-beta37")


### PR DESCRIPTION
fix #53 